### PR TITLE
Pass a 'de' accounting group when another group isn't provided

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -27,9 +27,9 @@ requirements = (HAS_HOST_MOUNTS == True){{ end }}
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
-log = condor.log{{if .Group}}
-accounting_group = {{.Group}}
-accounting_group_user = {{.Submitter}}{{end}}
+log = condor.log
+accounting_group = {{if .Group}}{{.Group}}{{else}}de{{end}}
+accounting_group_user = {{.Submitter}}
 request_disk = {{.RequestDisk}}
 +IpcUuid = "{{.InvocationID}}"
 +IpcJobId = "generated_script"


### PR DESCRIPTION
This will more nicely group users, and hopefully prioritize their jobs better too.

Basically, when you pass an accounting_group it lets you pass an accounting_group_user, which lets us override the user we normally submit everything as, without expecting it to run on the host machines as that user (just like for batch processing). This should hopefully mean that condor can track user priorities/usage, which it uses in matchmaking to be more fair. This, in turn, might hopefully mean we can lift (or at least increase dramatically) some of the limits we set, which would be good in order to use more of our condor pool at any given time.