### PR TITLE
CORE-9099 Update handleLaunchRequests to ACK messages after job launch.

### DIFF
--- a/condor.go
+++ b/condor.go
@@ -298,6 +298,8 @@ func (cl *CondorLauncher) handleLaunchRequests(condorPath, condorConfig string) 
 				}
 			}
 		default:
+			log.Errorf("condor_launches message handler got unrecognized command: %+v\n", req.Command)
+
 			if err := delivery.Ack(false); err != nil {
 				log.Error(errors.Wrap(err, "failed to ACK amqp Launch request delivery"))
 			}


### PR DESCRIPTION
This PR will update `handleLaunchRequests` to ACK AMQP messages only after handling the condor submission.

This function will now also reject AMQP messages (once) on errors.

These changes, along with a queue prefetch limit config setting, will prevent `too many open files` errors if many jobs are submitting at once (reproduced in dev by submitting 10 HT jobs at once with at least 100 sub-jobs each).