### PR TITLE
CORE-9103 Update `killHeldJobs` to use less resources

### DIFF
--- a/condor.go
+++ b/condor.go
@@ -358,20 +358,20 @@ func killHeldJobs(client *messaging.Client, condorPath, condorConfig string) {
 	var (
 		err         error
 		cmdOutput   []byte
-		heldEntries []queueEntry
+		heldEntries []string
 	)
 	log.Infoln("Looking for jobs in the held state...")
-	if cmdOutput, err = ExecCondorQ(condorPath, condorConfig); err != nil {
+	if cmdOutput, err = ExecCondorQHeldIDs(condorPath, condorConfig); err != nil {
 		log.Errorf("%+v\n", errors.Wrap(err, "error running condor_q"))
 		return
 	}
-	heldEntries = heldQueueEntries(cmdOutput)
+	heldEntries = heldQueueInvocationIDs(cmdOutput)
 	log.Infof("There are %d jobs in the held state", len(heldEntries))
-	for _, entry := range heldEntries {
-		if entry.InvocationID != "" {
-			log.Infof("Sending stop request for invocation id %s", entry.InvocationID)
+	for _, invocationID := range heldEntries {
+		if invocationID != "" {
+			log.Infof("Sending stop request for invocation id %s", invocationID)
 			if err = client.SendStopRequest(
-				entry.InvocationID,
+				invocationID,
 				"admin",
 				"Job was in held state",
 			); err != nil {

--- a/condor.go
+++ b/condor.go
@@ -310,11 +310,39 @@ func (cl *CondorLauncher) handleLaunchRequests(condorPath, condorConfig string) 
 	}
 }
 
+func (launcher *CondorLauncher) stopJob(invocationID, condorPath, condorConfig string) (error) {
+	var (
+		condorRMOutput []byte
+		err            error
+	)
+
+	log.Infof("Running condor_rm for %s", invocationID)
+	if condorRMOutput, err = ExecCondorRm(invocationID, condorPath, condorConfig); err != nil {
+		log.Errorf("%+v\n", errors.Wrapf(err, "failed to run 'condor_rm %s'", invocationID))
+		return err
+	}
+
+	fauxJob := model.New(launcher.cfg)
+	fauxJob.InvocationID = invocationID
+	update := &messaging.UpdateMessage{
+		Job:     fauxJob,
+		State:   messaging.FailedState,
+		Message: "Job was killed",
+	}
+	if err = launcher.client.PublishJobUpdate(update); err != nil {
+		log.Errorf("%+v\n", errors.Wrap(err, "failed to publish job update for a stopped job"))
+	}
+	log.Infof("condor_rm output for job %s:\n%s", invocationID, condorRMOutput)
+
+	launcher.client.DeleteQueue(messaging.StopQueueName(invocationID))
+
+	return nil
+}
+
 func (cl *CondorLauncher) stopHandler(condorPath, condorConfig string) func(d amqp.Delivery) {
 	return func(d amqp.Delivery) {
 		var (
 			requeueOnErr   bool
-			condorRMOutput []byte
 			invID          string
 			err            error
 		)
@@ -330,31 +358,15 @@ func (cl *CondorLauncher) stopHandler(condorPath, condorConfig string) func(d am
 
 		invID = stopRequest.InvocationID
 
-		log.Infof("Running condor_rm for %s", invID)
-		if condorRMOutput, err = ExecCondorRm(invID, condorPath, condorConfig); err != nil {
-			log.Errorf("%+v\n", errors.Wrapf(err, "failed to run 'condor_rm %s'", invID))
+		if err = cl.stopJob(invID, condorPath, condorConfig); err != nil {
 			rejectDelivery(d, requeueOnErr, fmt.Sprintf("failed to Reject StopRequest for %s", invID))
 		} else {
-			fauxJob := model.New(cl.cfg)
-			fauxJob.InvocationID = invID
-			update := &messaging.UpdateMessage{
-				Job:     fauxJob,
-				State:   messaging.FailedState,
-				Message: "Job was killed",
-			}
-			if err = cl.client.PublishJobUpdate(update); err != nil {
-				log.Errorf("%+v\n", errors.Wrap(err, "failed to publish job update for a stopped job"))
-			}
-			log.Infof("condor_rm output for job %s:\n%s", invID, condorRMOutput)
-
 			ackDelivery(d, fmt.Sprintf("failed to ACK StopRequest for %s", invID))
-
-			cl.client.DeleteQueue(messaging.StopQueueName(invID))
 		}
 	}
 }
 
-func killHeldJobs(client *messaging.Client, condorPath, condorConfig string) {
+func killHeldJobs(launcher *CondorLauncher, condorPath, condorConfig string) {
 	var (
 		err         error
 		cmdOutput   []byte
@@ -370,11 +382,7 @@ func killHeldJobs(client *messaging.Client, condorPath, condorConfig string) {
 	for _, invocationID := range heldEntries {
 		if invocationID != "" {
 			log.Infof("Sending stop request for invocation id %s", invocationID)
-			if err = client.SendStopRequest(
-				invocationID,
-				"admin",
-				"Job was in held state",
-			); err != nil {
+			if err = launcher.stopJob(invocationID, condorPath, condorConfig); err != nil {
 				log.Errorf("%+v\n", errors.Wrap(err, "error sending stop request"))
 			}
 		}
@@ -383,20 +391,20 @@ func killHeldJobs(client *messaging.Client, condorPath, condorConfig string) {
 
 // startHeldTicker starts up the code that periodically fires and clean up held
 // jobs
-func startHeldTicker(client *messaging.Client, condorPath, condorConfig string) (*time.Ticker, error) {
+func startHeldTicker(launcher *CondorLauncher, condorPath, condorConfig string) (*time.Ticker, error) {
 	d, err := time.ParseDuration("30s")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse duration '30s'")
 	}
 	t := time.NewTicker(d)
-	go func(t *time.Ticker, client *messaging.Client) {
+	go func(t *time.Ticker, launcher *CondorLauncher) {
 		for {
 			select {
 			case <-t.C:
-				killHeldJobs(client, condorPath, condorConfig)
+				killHeldJobs(launcher, condorPath, condorConfig)
 			}
 		}
-	}(t, client)
+	}(t, launcher)
 	return t, nil
 }
 
@@ -467,16 +475,6 @@ func main() {
 	condorPath := cfg.GetString("condor.path_env_var")
 	condorConfig := cfg.GetString("condor.condor_config")
 
-	ticker, err := startHeldTicker(
-		client,
-		condorPath,
-		condorConfig,
-	)
-	if err != nil {
-		log.Fatalf("%+v\n", err)
-	}
-	log.Infof("Started up the held state ticker: %#v", ticker)
-
 	launcher.v, err = VaultInit(
 		cfg.GetString("vault.token"),
 		cfg.GetString("vault.url"),
@@ -488,6 +486,16 @@ func main() {
 	if err = launcher.v.MountCubbyhole(cfg.GetString("vault.irods.mount_path")); err != nil {
 		log.Fatalf("%+v\n", err)
 	}
+
+	ticker, err := startHeldTicker(
+		launcher,
+		condorPath,
+		condorConfig,
+	)
+	if err != nil {
+		log.Fatalf("%+v\n", err)
+	}
+	log.Infof("Started up the held state ticker: %#v", ticker)
 
 	launcher.client.AddConsumer(
 		exchangeName,

--- a/stops_test.go
+++ b/stops_test.go
@@ -46,382 +46,65 @@ func exchangeName() string {
 }
 
 var (
-	listing = []byte(`RecentBlockReadKbytes = 0
-IpcJobId = "generated_script"
-BlockWrites = 0
-BlockWriteKbytes = 0
-BlockReads = 0
-BlockReadKbytes = 0
-BytesSent = 103469.0
-JobFinishedHookDone = 1437604709
-NumShadowStarts = 1
-JobStatus = 5
-JobCurrentStartDate = 1437604662
-TerminationPending = true
-MachineAttrSlotWeight0 = 3
-LastJobLeaseRenewal = 1437604708
-LastMatchTime = 1437604662
-LastRemoteHost = "slot1@shadowcat.iplantcollaborative.org"
-MemoryUsage = ( ( ResidentSetSize + 1023 ) / 1024 )
-IpcExe = "wc_wrapper.sh"
-IpcUuid = "eca67a7c-e745-4e98-b892-67a9948bc2cb"
-NumCkpts = 0
-ClusterId = 3
-CurrentTime = time()
-PeriodicRelease = false
-WantCheckpoint = false
-Arguments = "iplant.sh"
-RemoteWallClockTime = 47.0
-ImageSize_RAW = 194760
-LeaveJobInQueue = false
-BufferBlockSize = 32768
-ExitCode = 0
-CompletionDate = 1437604709
-User = "condor@iplantcollaborative.org"
-RemoteSysCpu = 0.0
-ExecutableSize = 1000
-LocalUserCpu = 0.0
-TransferInput = "iplant.sh,irods-config,iplant.cmd"
-RemoteUserCpu = 0.0
-NiceUser = false
-JobRunCount = 1
-CumulativeSlotTime = 141.0
-TransferInputSizeMB = 0
-CondorPlatform = "$CondorPlatform: X86_64-RedHat_7.0 $"
-Environment = ""
-BufferSize = 524288
-Owner = "condor"
-JobNotification = 0
-BytesRecvd = 963523.0
-RequestMemory = ifthenelse(MemoryUsage =!= undefined,MemoryUsage,( ImageSize + 1023 ) / 1024)
-MaxHosts = 1
-UserLog = "/tmp/sriram/Word_Count_analysis1-2015-07-22-15-37-34.705/logs/condor.log"
-IpcUsername = "sriram"
-Out = "script-output.log"
-MinHosts = 1
-Requirements = ( TARGET.Arch == "X86_64" ) && ( TARGET.OpSys == "LINUX" ) && ( TARGET.Memory >= RequestMemory ) && ( TARGET.HasFileTransfer )
-SpooledOutputFiles = "de-transfer-trigger.log"
-RequestCpus = 1
-AutoClusterAttrs = "JobUniverse,LastCheckpointPlatform,NumCkpts,IpcExe,MachineLastMatchTime,ImageSize,MemoryUsage,RequestMemory,ResidentSetSize,Requirements,Rank,NiceUser,ConcurrencyLimits"
-JobUniverse = 5
-ExitBySignal = false
-JobPrio = 0
-NumJobMatches = 1
-RootDir = "/"
-GlobalJobId = "rocinante.iplantcollaborative.org#3.0#1437604654"
-CurrentHosts = 0
-JobStartDate = 1437604662
-CoreSize = 0
-OnExitHold = false
-LocalSysCpu = 0.0
-Iwd = "/tmp/sriram/Word_Count_analysis1-2015-07-22-15-37-34.705/logs"
-PeriodicHold = false
-ProcId = 0
-CommittedSuspensionTime = 0
-StatsLifetimeStarter = 45
-ImageSize = 200000
-CondorVersion = "$CondorVersion: 8.2.8 Apr 07 2015 BuildID: UW_development $"
-Err = "script-error.log"
-PeriodicRemove = false
-ConcurrencyLimits = "sriram"
-TransferOutput = "logs/de-transfer-trigger.log"
-StreamErr = false
-DiskUsage_RAW = 1115
-OnExitRemove = true
-DiskUsage = 1250
-In = "/dev/null"
-TargetType = "Machine"
-WhenToTransferOutput = "ON_EXIT_OR_EVICT"
-ResidentSetSize = 2250
-StreamOut = false
-WantRemoteIO = true
-CommittedSlotTime = 141.0
-TotalSuspensions = 0
-ExecutableSize_RAW = 938
-LastSuspensionTime = 0
-CommittedTime = 47
-IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-Cmd = "/bin/bash"
-NumJobStarts = 1
-EnteredCurrentStatus = 1437604709
-JobLeaseDuration = 1200
-QDate = 1437604654
-WantRemoteSyscalls = false
-MachineAttrCpus0 = 3
-ShouldTransferFiles = "YES"
-ExitStatus = 0
-AutoClusterId = 5
-Rank = mips
-MyType = "Job"
-CumulativeSuspensionTime = 0
-NumSystemHolds = 0
-NumRestarts = 0
-RecentBlockWrites = 0
-NumCkpts_RAW = 0
-LastPublicClaimId = "<150.135.78.112:63306>#1437583342#12#..."
-RecentStatsLifetimeStarter = 37
-TransferIn = false
-RecentBlockWriteKbytes = 0
-JobCurrentStartExecutingDate = 1437604663
-LastJobStatus = 2
-StartdPrincipal = "unauthenticated@unmapped/150.135.78.112"
-ResidentSetSize_RAW = 2188
-RequestDisk = 0
-OrigMaxHosts = 1
-RecentBlockReads = 0
+	listing = []byte(`
+63c5523d-d8a5-49bc-addc-99a73566cd89
+b788569f-6948-4586-b5bd-5ea096986331
+eca67a7c-e745-4e98-b892-67a9948bc2cb
 
-RecentBlockReadKbytes = 0
-IpcJobId = "generated_script"
-BlockWrites = 0
-BlockWriteKbytes = 0
-BlockReads = 0
-BlockReadKbytes = 0
-BytesSent = 106927.0
-JobFinishedHookDone = 1437600186
-NumShadowStarts = 1
-JobStatus = 5
-JobCurrentStartDate = 1437599749
-TerminationPending = true
-MachineAttrSlotWeight0 = 3
-LastJobLeaseRenewal = 1437600185
-LastMatchTime = 1437599749
-LastRemoteHost = "slot1@shadowcat.iplantcollaborative.org"
-MemoryUsage = ( ( ResidentSetSize + 1023 ) / 1024 )
-IpcExe = "wc_wrapper.sh"
-NumCkpts = 0
-ClusterId = 1
-CurrentTime = time()
-PeriodicRelease = false
-WantCheckpoint = false
-Arguments = "iplant.sh"
-RemoteWallClockTime = 437.0
-ImageSize_RAW = 196812
-LeaveJobInQueue = false
-BufferBlockSize = 32768
-ExitCode = 0
-CompletionDate = 1437600186
-User = "condor@iplantcollaborative.org"
-RemoteSysCpu = 0.0
-ExecutableSize = 1000
-LocalUserCpu = 0.0
-TransferInput = "iplant.sh,irods-config,iplant.cmd"
-RemoteUserCpu = 1.0
-NiceUser = false
-JobRunCount = 1
-CumulativeSlotTime = 1311.0
-TransferInputSizeMB = 0
-CondorPlatform = "$CondorPlatform: X86_64-RedHat_7.0 $"
-Environment = ""
-BufferSize = 524288
-Owner = "condor"
-JobNotification = 0
-BytesRecvd = 963569.0
-RequestMemory = ifthenelse(MemoryUsage =!= undefined,MemoryUsage,( ImageSize + 1023 ) / 1024)
-MaxHosts = 1
-UserLog = "/tmp/wregglej/Word_Count_analysis1-2015-07-22-14-15-39.005/logs/condor.log"
-IpcUsername = "wregglej"
-Out = "script-output.log"
-MinHosts = 1
-Requirements = ( TARGET.Arch == "X86_64" ) && ( TARGET.OpSys == "LINUX" ) && ( TARGET.Memory >= RequestMemory ) && ( TARGET.HasFileTransfer )
-SpooledOutputFiles = "de-transfer-trigger.log"
-RequestCpus = 1
-JobUniverse = 5
-ExitBySignal = false
-JobPrio = 0
-NumJobMatches = 1
-RootDir = "/"
-GlobalJobId = "rocinante.iplantcollaborative.org#1.0#1437599739"
-CurrentHosts = 0
-JobStartDate = 1437599749
-CoreSize = 0
-OnExitHold = false
-LocalSysCpu = 0.0
-Iwd = "/tmp/wregglej/Word_Count_analysis1-2015-07-22-14-15-39.005/logs"
-PeriodicHold = false
-ProcId = 0
-CommittedSuspensionTime = 0
-StatsLifetimeStarter = 436
-ImageSize = 200000
-CondorVersion = "$CondorVersion: 8.2.8 Apr 07 2015 BuildID: UW_development $"
-Err = "script-error.log"
-PeriodicRemove = false
-ConcurrencyLimits = "wregglej"
-TransferOutput = "logs/de-transfer-trigger.log"
-StreamErr = false
-DiskUsage_RAW = 1118
-OnExitRemove = true
-DiskUsage = 1250
-In = "/dev/null"
-TargetType = "Machine"
-WhenToTransferOutput = "ON_EXIT_OR_EVICT"
-ResidentSetSize = 10000
-StreamOut = false
-WantRemoteIO = true
-CommittedSlotTime = 1311.0
-TotalSuspensions = 0
-ExecutableSize_RAW = 938
-LastSuspensionTime = 0
-CommittedTime = 437
-IpcUuid = "b788569f-6948-4586-b5bd-5ea096986331"
-NumJobStarts = 1
-EnteredCurrentStatus = 1437600186
-JobLeaseDuration = 1200
-QDate = 1437599739
-WantRemoteSyscalls = false
-MachineAttrCpus0 = 3
-ShouldTransferFiles = "YES"
-ExitStatus = 0
-Rank = mips
-MyType = "Job"
-CumulativeSuspensionTime = 0
-NumSystemHolds = 0
-NumRestarts = 0
-RecentBlockWrites = 0
-NumCkpts_RAW = 0
-LastPublicClaimId = "<150.135.78.112:63306>#1437583342#1#..."
-RecentStatsLifetimeStarter = 427
-TransferIn = false
-RecentBlockWriteKbytes = 0
-JobCurrentStartExecutingDate = 1437599749
-LastJobStatus = 2
-StartdPrincipal = "unauthenticated@unmapped/150.135.78.112"
-ResidentSetSize_RAW = 9676
-RequestDisk = 0
-OrigMaxHosts = 1
-RecentBlockReads = 0
-Cmd = "/bin/bash"
-IpcExePath = "/usr/local3/bin/wc_tool-1.00"
+571722aa-f46c-40fd-a688-69068fb52ee1
+105fba2c-c9a5-4a89-8033-9d3b3e5c419f
+51d4cb60-e925-4229-a257-8d5b6feeedb8
+22c13517-4a2d-4874-92b3-5b5d03299d60
+316bc5ba-aaee-4922-a8c7-ea9479a65650
+1e0cc85e-6053-452c-b1a9-cedc0f12cf7b
+7ffa2752-e7bf-4eae-8ed5-b366aef7978e
+d9eaa702-14d5-439e-b01f-4ca3a39096ec
+57ff5e6b-5a4f-496b-9f66-eeadfbd03e86
+0af6c62a-3570-46de-9f27-9b6c430bd912
+0d607f70-ad65-4a8c-bfe3-1b0efb7a20e9
+10af43af-6f63-4305-8bad-e70ae208ec4c
+1fa4bea3-8f3e-472e-9981-3b1a5b0d425e
+30282173-70e5-4055-8621-a3a149db1829
+9b21c5c6-19b3-45cc-9e87-720d57032e71
+6a54a3bc-1a42-453d-9fa9-81300804f26f
+827624c9-1e1b-4783-ab7a-23e78c599cc3
+c6193b50-cdaa-48c8-aa69-3957431b05a2
+d0952a64-8d7c-4d2b-9046-6c91425e0671
 
-RecentBlockReadKbytes = 0
-IpcJobId = "generated_script"
-BlockWrites = 0
-BlockWriteKbytes = 0
-BlockReads = 0
-BlockReadKbytes = 0
-BytesSent = 99709.0
-JobFinishedHookDone = 1437600183
-NumShadowStarts = 1
-JobStatus = 5
-JobCurrentStartDate = 1437599789
-TerminationPending = true
-MachineAttrSlotWeight0 = 3
-LastJobLeaseRenewal = 1437600182
-LastMatchTime = 1437599789
-LastRemoteHost = "slot2@shadowcat.iplantcollaborative.org"
-MemoryUsage = ( ( ResidentSetSize + 1023 ) / 1024 )
-IpcExe = "wc_wrapper.sh"
-IpcUuid = "63c5523d-d8a5-49bc-addc-99a73566cd89"
-NumCkpts = 0
-ClusterId = 2
-CurrentTime = time()
-PeriodicRelease = false
-WantCheckpoint = false
-Arguments = "iplant.sh"
-RemoteWallClockTime = 394.0
-ImageSize_RAW = 196812
-LeaveJobInQueue = false
-BufferBlockSize = 32768
-ExitCode = 1
-CompletionDate = 1437600183
-User = "condor@iplantcollaborative.org"
-RemoteSysCpu = 0.0
-ExecutableSize = 1000
-LocalUserCpu = 0.0
-TransferInput = "iplant.sh,irods-config,iplant.cmd"
-RemoteUserCpu = 0.0
-NiceUser = false
-JobRunCount = 1
-CumulativeSlotTime = 1182.0
-TransferInputSizeMB = 0
-CondorPlatform = "$CondorPlatform: X86_64-RedHat_7.0 $"
-Environment = ""
-BufferSize = 524288
-Owner = "condor"
-JobNotification = 0
-BytesRecvd = 963523.0
-RequestMemory = ifthenelse(MemoryUsage =!= undefined,MemoryUsage,( ImageSize + 1023 ) / 1024)
-MaxHosts = 1
-UserLog = "/tmp/sriram/Word_Count_analysis1-2015-07-22-14-16-29.284/logs/condor.log"
-IpcUsername = "sriram"
-Out = "script-output.log"
-MinHosts = 1
-Requirements = ( TARGET.Arch == "X86_64" ) && ( TARGET.OpSys == "LINUX" ) && ( TARGET.Memory >= RequestMemory ) && ( TARGET.HasFileTransfer )
-SpooledOutputFiles = "de-transfer-trigger.log"
-RequestCpus = 1
-AutoClusterAttrs = "JobUniverse,LastCheckpointPlatform,NumCkpts,IpcExe,MachineLastMatchTime,ImageSize,MemoryUsage,RequestMemory,ResidentSetSize,Requirements,Rank,NiceUser,ConcurrencyLimits"
-JobUniverse = 5
-ExitBySignal = false
-JobPrio = 0
-NumJobMatches = 1
-RootDir = "/"
-GlobalJobId = "rocinante.iplantcollaborative.org#2.0#1437599789"
-CurrentHosts = 0
-JobStartDate = 1437599789
-CoreSize = 0
-OnExitHold = false
-LocalSysCpu = 0.0
-Iwd = "/tmp/sriram/Word_Count_analysis1-2015-07-22-14-16-29.284/logs"
-PeriodicHold = false
-ProcId = 0
-CommittedSuspensionTime = 0
-StatsLifetimeStarter = 393
-ImageSize = 200000
-CondorVersion = "$CondorVersion: 8.2.8 Apr 07 2015 BuildID: UW_development $"
-Err = "script-error.log"
-PeriodicRemove = false
-ConcurrencyLimits = "sriram"
-TransferOutput = "logs/de-transfer-trigger.log"
-StreamErr = false
-DiskUsage_RAW = 1107
-OnExitRemove = true
-DiskUsage = 1250
-In = "/dev/null"
-TargetType = "Machine"
-WhenToTransferOutput = "ON_EXIT_OR_EVICT"
-ResidentSetSize = 10000
-StreamOut = false
-WantRemoteIO = true
-CommittedSlotTime = 1182.0
-TotalSuspensions = 0
-ExecutableSize_RAW = 938
-LastSuspensionTime = 0
-CommittedTime = 394
-IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-Cmd = "/bin/bash"
-NumJobStarts = 1
-EnteredCurrentStatus = 1437600183
-JobLeaseDuration = 1200
-QDate = 1437599789
-WantRemoteSyscalls = false
-MachineAttrCpus0 = 3
-ShouldTransferFiles = "YES"
-ExitStatus = 0
-AutoClusterId = 3
-Rank = mips
-MyType = "Job"
-CumulativeSuspensionTime = 0
-NumSystemHolds = 0
-NumRestarts = 0
-RecentBlockWrites = 0
-NumCkpts_RAW = 0
-LastPublicClaimId = "<150.135.78.112:63306>#1437583342#2#..."
-RecentStatsLifetimeStarter = 384
-TransferIn = false
-RecentBlockWriteKbytes = 0
-JobCurrentStartExecutingDate = 1437599789
-LastJobStatus = 2
-StartdPrincipal = "unauthenticated@unmapped/150.135.78.112"
-ResidentSetSize_RAW = 9488
-RequestDisk = 0
-OrigMaxHosts = 1
-RecentBlockReads = 0`)
+4457ec2d-5203-4ab6-95e5-2831d998dd1f
+6e7d9735-1fc7-4626-b5d3-91993eae7a1b
+3c967e99-51ff-484d-a000-3ce3adf744ce
+8d64bc74-750a-4cd3-bbf3-2d9a4e56fcf0
+77ac1023-c6d1-403c-8088-04205a270c7a
+dc9f2455-da10-42c6-bc58-b7a963b46338
+74a17e36-ac52-4dde-9abb-e5a8dca0b2c6
+7446aa7b-16db-4b4f-ad8d-8d802b402aaa
+ee6cdfe9-bd90-460a-bb5f-b10b3e299b10
+a45770ad-cc7d-4fc8-8b1a-ffb75bd44e0e
+dd632e6c-50e7-4b81-bb07-9d2abe0a9b15
+f532df1e-591e-47f1-84e6-fdf670727040
+12febe03-ae83-48f2-b828-c2865fecf09e
+e802a7b5-13f2-462d-ac85-f9836a4fd575
+18f6b09f-63bd-4825-a34e-4767dee4f358
+4a039e5a-0335-45ee-880b-5495c92bfc9a
+6123e600-ec4f-4d29-b2c4-edd0af089b04
+ba30efdd-4207-4120-91dd-de5caed467ae
+9d20a879-6d33-43b4-b430-0c1cfaf5a7c4
+8f4002c0-d650-4252-943d-56287b6c6efe
+3c5c986e-1b69-4ff2-a470-0f677148240e
+f0ffb7ee-b7c6-4a07-814b-88d76b3cc3b8
+65ecca14-759e-41ee-b764-069ac0155df5
+36770cc9-d80b-405c-b9be-c5977ae3e83b
+4a4926a6-2a18-4b37-a361-581658a0f067
+15384749-bc5f-43ff-854e-b6495e0c6ee4
+2e8c0c9c-133a-4436-b1a4-3bb303ce7cd3`)
 )
 
 func isInvocationIDHeld(condorQListing []byte, invocationID string) bool {
-	actual := heldQueueEntries(condorQListing)
-	for _, entry := range actual {
-		if entry.InvocationID == invocationID {
-			return entry.IsHeld
+	actual := heldQueueInvocationIDs(condorQListing)
+	for _, uuid := range actual {
+		if uuid == invocationID {
+			return true
 		}
 	}
 
@@ -450,7 +133,7 @@ func TestCondorID(t *testing.T) {
 
 func TestExecCondorQ(t *testing.T) {
 	inittests(t)
-	output, err := ExecCondorQ("", "")
+	output, err := ExecCondorQHeldIDs("", "")
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/condor_q
+++ b/test/condor_q
@@ -1,372 +1,54 @@
 #!/bin/sh
 
 echo '
-RecentBlockReadKbytes = 0
-IpcJobId = "generated_script"
-BlockWrites = 0
-BlockWriteKbytes = 0
-BlockReads = 0
-BlockReadKbytes = 0
-BytesSent = 103469.0
-JobFinishedHookDone = 1437604709
-NumShadowStarts = 1
-JobStatus = 5
-JobCurrentStartDate = 1437604662
-TerminationPending = true
-MachineAttrSlotWeight0 = 3
-LastJobLeaseRenewal = 1437604708
-LastMatchTime = 1437604662
-LastRemoteHost = "slot1@shadowcat.iplantcollaborative.org"
-MemoryUsage = ( ( ResidentSetSize + 1023 ) / 1024 )
-IpcExe = "wc_wrapper.sh"
-IpcUuid = "eca67a7c-e745-4e98-b892-67a9948bc2cb"
-NumCkpts = 0
-ClusterId = 3
-CurrentTime = time()
-PeriodicRelease = false
-WantCheckpoint = false
-Arguments = "iplant.sh"
-RemoteWallClockTime = 47.0
-ImageSize_RAW = 194760
-LeaveJobInQueue = false
-BufferBlockSize = 32768
-ExitCode = 0
-CompletionDate = 1437604709
-User = "condor@iplantcollaborative.org"
-RemoteSysCpu = 0.0
-ExecutableSize = 1000
-LocalUserCpu = 0.0
-TransferInput = "iplant.sh,irods-config,iplant.cmd"
-RemoteUserCpu = 0.0
-NiceUser = false
-JobRunCount = 1
-CumulativeSlotTime = 141.0
-TransferInputSizeMB = 0
-CondorPlatform = "$CondorPlatform: X86_64-RedHat_7.0 $"
-Environment = ""
-BufferSize = 524288
-Owner = "condor"
-JobNotification = 0
-BytesRecvd = 963523.0
-RequestMemory = ifthenelse(MemoryUsage =!= undefined,MemoryUsage,( ImageSize + 1023 ) / 1024)
-MaxHosts = 1
-UserLog = "/tmp/sriram/Word_Count_analysis1-2015-07-22-15-37-34.705/logs/condor.log"
-IpcUsername = "sriram"
-Out = "script-output.log"
-MinHosts = 1
-Requirements = ( TARGET.Arch == "X86_64" ) && ( TARGET.OpSys == "LINUX" ) && ( TARGET.Memory >= RequestMemory ) && ( TARGET.HasFileTransfer )
-SpooledOutputFiles = "de-transfer-trigger.log"
-RequestCpus = 1
-AutoClusterAttrs = "JobUniverse,LastCheckpointPlatform,NumCkpts,IpcExe,MachineLastMatchTime,ImageSize,MemoryUsage,RequestMemory,ResidentSetSize,Requirements,Rank,NiceUser,ConcurrencyLimits"
-JobUniverse = 5
-ExitBySignal = false
-JobPrio = 0
-NumJobMatches = 1
-RootDir = "/"
-GlobalJobId = "rocinante.iplantcollaborative.org#3.0#1437604654"
-CurrentHosts = 0
-JobStartDate = 1437604662
-CoreSize = 0
-OnExitHold = false
-LocalSysCpu = 0.0
-Iwd = "/tmp/sriram/Word_Count_analysis1-2015-07-22-15-37-34.705/logs"
-PeriodicHold = false
-ProcId = 0
-CommittedSuspensionTime = 0
-StatsLifetimeStarter = 45
-ImageSize = 200000
-CondorVersion = "$CondorVersion: 8.2.8 Apr 07 2015 BuildID: UW_development $"
-Err = "script-error.log"
-PeriodicRemove = false
-ConcurrencyLimits = "sriram"
-TransferOutput = "logs/de-transfer-trigger.log"
-StreamErr = false
-DiskUsage_RAW = 1115
-OnExitRemove = true
-DiskUsage = 1250
-In = "/dev/null"
-TargetType = "Machine"
-WhenToTransferOutput = "ON_EXIT_OR_EVICT"
-ResidentSetSize = 2250
-StreamOut = false
-WantRemoteIO = true
-CommittedSlotTime = 141.0
-TotalSuspensions = 0
-ExecutableSize_RAW = 938
-LastSuspensionTime = 0
-CommittedTime = 47
-IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-Cmd = "/bin/bash"
-NumJobStarts = 1
-EnteredCurrentStatus = 1437604709
-JobLeaseDuration = 1200
-QDate = 1437604654
-WantRemoteSyscalls = false
-MachineAttrCpus0 = 3
-ShouldTransferFiles = "YES"
-ExitStatus = 0
-AutoClusterId = 5
-Rank = mips
-MyType = "Job"
-CumulativeSuspensionTime = 0
-NumSystemHolds = 0
-NumRestarts = 0
-RecentBlockWrites = 0
-NumCkpts_RAW = 0
-LastPublicClaimId = "<150.135.78.112:63306>#1437583342#12#..."
-RecentStatsLifetimeStarter = 37
-TransferIn = false
-RecentBlockWriteKbytes = 0
-JobCurrentStartExecutingDate = 1437604663
-LastJobStatus = 2
-StartdPrincipal = "unauthenticated@unmapped/150.135.78.112"
-ResidentSetSize_RAW = 2188
-RequestDisk = 0
-OrigMaxHosts = 1
-RecentBlockReads = 0
+63c5523d-d8a5-49bc-addc-99a73566cd89
+b788569f-6948-4586-b5bd-5ea096986331
+eca67a7c-e745-4e98-b892-67a9948bc2cb
 
-RecentBlockReadKbytes = 0
-IpcJobId = "generated_script"
-BlockWrites = 0
-BlockWriteKbytes = 0
-BlockReads = 0
-BlockReadKbytes = 0
-BytesSent = 106927.0
-JobFinishedHookDone = 1437600186
-NumShadowStarts = 1
-JobStatus = 5
-JobCurrentStartDate = 1437599749
-TerminationPending = true
-MachineAttrSlotWeight0 = 3
-LastJobLeaseRenewal = 1437600185
-LastMatchTime = 1437599749
-LastRemoteHost = "slot1@shadowcat.iplantcollaborative.org"
-MemoryUsage = ( ( ResidentSetSize + 1023 ) / 1024 )
-IpcExe = "wc_wrapper.sh"
-NumCkpts = 0
-ClusterId = 1
-CurrentTime = time()
-PeriodicRelease = false
-WantCheckpoint = false
-Arguments = "iplant.sh"
-RemoteWallClockTime = 437.0
-ImageSize_RAW = 196812
-LeaveJobInQueue = false
-BufferBlockSize = 32768
-ExitCode = 0
-CompletionDate = 1437600186
-User = "condor@iplantcollaborative.org"
-RemoteSysCpu = 0.0
-ExecutableSize = 1000
-LocalUserCpu = 0.0
-TransferInput = "iplant.sh,irods-config,iplant.cmd"
-RemoteUserCpu = 1.0
-NiceUser = false
-JobRunCount = 1
-CumulativeSlotTime = 1311.0
-TransferInputSizeMB = 0
-CondorPlatform = "$CondorPlatform: X86_64-RedHat_7.0 $"
-Environment = ""
-BufferSize = 524288
-Owner = "condor"
-JobNotification = 0
-BytesRecvd = 963569.0
-RequestMemory = ifthenelse(MemoryUsage =!= undefined,MemoryUsage,( ImageSize + 1023 ) / 1024)
-MaxHosts = 1
-UserLog = "/tmp/wregglej/Word_Count_analysis1-2015-07-22-14-15-39.005/logs/condor.log"
-IpcUsername = "wregglej"
-Out = "script-output.log"
-MinHosts = 1
-Requirements = ( TARGET.Arch == "X86_64" ) && ( TARGET.OpSys == "LINUX" ) && ( TARGET.Memory >= RequestMemory ) && ( TARGET.HasFileTransfer )
-SpooledOutputFiles = "de-transfer-trigger.log"
-RequestCpus = 1
-JobUniverse = 5
-ExitBySignal = false
-JobPrio = 0
-NumJobMatches = 1
-RootDir = "/"
-GlobalJobId = "rocinante.iplantcollaborative.org#1.0#1437599739"
-CurrentHosts = 0
-JobStartDate = 1437599749
-CoreSize = 0
-OnExitHold = false
-LocalSysCpu = 0.0
-Iwd = "/tmp/wregglej/Word_Count_analysis1-2015-07-22-14-15-39.005/logs"
-PeriodicHold = false
-ProcId = 0
-CommittedSuspensionTime = 0
-StatsLifetimeStarter = 436
-ImageSize = 200000
-CondorVersion = "$CondorVersion: 8.2.8 Apr 07 2015 BuildID: UW_development $"
-Err = "script-error.log"
-PeriodicRemove = false
-ConcurrencyLimits = "wregglej"
-TransferOutput = "logs/de-transfer-trigger.log"
-StreamErr = false
-DiskUsage_RAW = 1118
-OnExitRemove = true
-DiskUsage = 1250
-In = "/dev/null"
-TargetType = "Machine"
-WhenToTransferOutput = "ON_EXIT_OR_EVICT"
-ResidentSetSize = 10000
-StreamOut = false
-WantRemoteIO = true
-CommittedSlotTime = 1311.0
-TotalSuspensions = 0
-ExecutableSize_RAW = 938
-LastSuspensionTime = 0
-CommittedTime = 437
-IpcUuid = "b788569f-6948-4586-b5bd-5ea096986331"
-NumJobStarts = 1
-EnteredCurrentStatus = 1437600186
-JobLeaseDuration = 1200
-QDate = 1437599739
-WantRemoteSyscalls = false
-MachineAttrCpus0 = 3
-ShouldTransferFiles = "YES"
-ExitStatus = 0
-Rank = mips
-MyType = "Job"
-CumulativeSuspensionTime = 0
-NumSystemHolds = 0
-NumRestarts = 0
-RecentBlockWrites = 0
-NumCkpts_RAW = 0
-LastPublicClaimId = "<150.135.78.112:63306>#1437583342#1#..."
-RecentStatsLifetimeStarter = 427
-TransferIn = false
-RecentBlockWriteKbytes = 0
-JobCurrentStartExecutingDate = 1437599749
-LastJobStatus = 2
-StartdPrincipal = "unauthenticated@unmapped/150.135.78.112"
-ResidentSetSize_RAW = 9676
-RequestDisk = 0
-OrigMaxHosts = 1
-RecentBlockReads = 0
-Cmd = "/bin/bash"
-IpcExePath = "/usr/local3/bin/wc_tool-1.00"
+571722aa-f46c-40fd-a688-69068fb52ee1
+105fba2c-c9a5-4a89-8033-9d3b3e5c419f
+51d4cb60-e925-4229-a257-8d5b6feeedb8
+22c13517-4a2d-4874-92b3-5b5d03299d60
+316bc5ba-aaee-4922-a8c7-ea9479a65650
+1e0cc85e-6053-452c-b1a9-cedc0f12cf7b
+7ffa2752-e7bf-4eae-8ed5-b366aef7978e
+d9eaa702-14d5-439e-b01f-4ca3a39096ec
+57ff5e6b-5a4f-496b-9f66-eeadfbd03e86
+0af6c62a-3570-46de-9f27-9b6c430bd912
+0d607f70-ad65-4a8c-bfe3-1b0efb7a20e9
+10af43af-6f63-4305-8bad-e70ae208ec4c
+1fa4bea3-8f3e-472e-9981-3b1a5b0d425e
+30282173-70e5-4055-8621-a3a149db1829
+9b21c5c6-19b3-45cc-9e87-720d57032e71
+6a54a3bc-1a42-453d-9fa9-81300804f26f
+827624c9-1e1b-4783-ab7a-23e78c599cc3
+c6193b50-cdaa-48c8-aa69-3957431b05a2
+d0952a64-8d7c-4d2b-9046-6c91425e0671
 
-RecentBlockReadKbytes = 0
-IpcJobId = "generated_script"
-BlockWrites = 0
-BlockWriteKbytes = 0
-BlockReads = 0
-BlockReadKbytes = 0
-BytesSent = 99709.0
-JobFinishedHookDone = 1437600183
-NumShadowStarts = 1
-JobStatus = 5
-JobCurrentStartDate = 1437599789
-TerminationPending = true
-MachineAttrSlotWeight0 = 3
-LastJobLeaseRenewal = 1437600182
-LastMatchTime = 1437599789
-LastRemoteHost = "slot2@shadowcat.iplantcollaborative.org"
-MemoryUsage = ( ( ResidentSetSize + 1023 ) / 1024 )
-IpcExe = "wc_wrapper.sh"
-IpcUuid = "63c5523d-d8a5-49bc-addc-99a73566cd89"
-NumCkpts = 0
-ClusterId = 2
-CurrentTime = time()
-PeriodicRelease = false
-WantCheckpoint = false
-Arguments = "iplant.sh"
-RemoteWallClockTime = 394.0
-ImageSize_RAW = 196812
-LeaveJobInQueue = false
-BufferBlockSize = 32768
-ExitCode = 1
-CompletionDate = 1437600183
-User = "condor@iplantcollaborative.org"
-RemoteSysCpu = 0.0
-ExecutableSize = 1000
-LocalUserCpu = 0.0
-TransferInput = "iplant.sh,irods-config,iplant.cmd"
-RemoteUserCpu = 0.0
-NiceUser = false
-JobRunCount = 1
-CumulativeSlotTime = 1182.0
-TransferInputSizeMB = 0
-CondorPlatform = "$CondorPlatform: X86_64-RedHat_7.0 $"
-Environment = ""
-BufferSize = 524288
-Owner = "condor"
-JobNotification = 0
-BytesRecvd = 963523.0
-RequestMemory = ifthenelse(MemoryUsage =!= undefined,MemoryUsage,( ImageSize + 1023 ) / 1024)
-MaxHosts = 1
-UserLog = "/tmp/sriram/Word_Count_analysis1-2015-07-22-14-16-29.284/logs/condor.log"
-IpcUsername = "sriram"
-Out = "script-output.log"
-MinHosts = 1
-Requirements = ( TARGET.Arch == "X86_64" ) && ( TARGET.OpSys == "LINUX" ) && ( TARGET.Memory >= RequestMemory ) && ( TARGET.HasFileTransfer )
-SpooledOutputFiles = "de-transfer-trigger.log"
-RequestCpus = 1
-AutoClusterAttrs = "JobUniverse,LastCheckpointPlatform,NumCkpts,IpcExe,MachineLastMatchTime,ImageSize,MemoryUsage,RequestMemory,ResidentSetSize,Requirements,Rank,NiceUser,ConcurrencyLimits"
-JobUniverse = 5
-ExitBySignal = false
-JobPrio = 0
-NumJobMatches = 1
-RootDir = "/"
-GlobalJobId = "rocinante.iplantcollaborative.org#2.0#1437599789"
-CurrentHosts = 0
-JobStartDate = 1437599789
-CoreSize = 0
-OnExitHold = false
-LocalSysCpu = 0.0
-Iwd = "/tmp/sriram/Word_Count_analysis1-2015-07-22-14-16-29.284/logs"
-PeriodicHold = false
-ProcId = 0
-CommittedSuspensionTime = 0
-StatsLifetimeStarter = 393
-ImageSize = 200000
-CondorVersion = "$CondorVersion: 8.2.8 Apr 07 2015 BuildID: UW_development $"
-Err = "script-error.log"
-PeriodicRemove = false
-ConcurrencyLimits = "sriram"
-TransferOutput = "logs/de-transfer-trigger.log"
-StreamErr = false
-DiskUsage_RAW = 1107
-OnExitRemove = true
-DiskUsage = 1250
-In = "/dev/null"
-TargetType = "Machine"
-WhenToTransferOutput = "ON_EXIT_OR_EVICT"
-ResidentSetSize = 10000
-StreamOut = false
-WantRemoteIO = true
-CommittedSlotTime = 1182.0
-TotalSuspensions = 0
-ExecutableSize_RAW = 938
-LastSuspensionTime = 0
-CommittedTime = 394
-IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-Cmd = "/bin/bash"
-NumJobStarts = 1
-EnteredCurrentStatus = 1437600183
-JobLeaseDuration = 1200
-QDate = 1437599789
-WantRemoteSyscalls = false
-MachineAttrCpus0 = 3
-ShouldTransferFiles = "YES"
-ExitStatus = 0
-AutoClusterId = 3
-Rank = mips
-MyType = "Job"
-CumulativeSuspensionTime = 0
-NumSystemHolds = 0
-NumRestarts = 0
-RecentBlockWrites = 0
-NumCkpts_RAW = 0
-LastPublicClaimId = "<150.135.78.112:63306>#1437583342#2#..."
-RecentStatsLifetimeStarter = 384
-TransferIn = false
-RecentBlockWriteKbytes = 0
-JobCurrentStartExecutingDate = 1437599789
-LastJobStatus = 2
-StartdPrincipal = "unauthenticated@unmapped/150.135.78.112"
-ResidentSetSize_RAW = 9488
-RequestDisk = 0
-OrigMaxHosts = 1
-RecentBlockReads = 0'
+4457ec2d-5203-4ab6-95e5-2831d998dd1f
+6e7d9735-1fc7-4626-b5d3-91993eae7a1b
+3c967e99-51ff-484d-a000-3ce3adf744ce
+8d64bc74-750a-4cd3-bbf3-2d9a4e56fcf0
+77ac1023-c6d1-403c-8088-04205a270c7a
+dc9f2455-da10-42c6-bc58-b7a963b46338
+74a17e36-ac52-4dde-9abb-e5a8dca0b2c6
+7446aa7b-16db-4b4f-ad8d-8d802b402aaa
+ee6cdfe9-bd90-460a-bb5f-b10b3e299b10
+a45770ad-cc7d-4fc8-8b1a-ffb75bd44e0e
+dd632e6c-50e7-4b81-bb07-9d2abe0a9b15
+f532df1e-591e-47f1-84e6-fdf670727040
+12febe03-ae83-48f2-b828-c2865fecf09e
+e802a7b5-13f2-462d-ac85-f9836a4fd575
+18f6b09f-63bd-4825-a34e-4767dee4f358
+4a039e5a-0335-45ee-880b-5495c92bfc9a
+6123e600-ec4f-4d29-b2c4-edd0af089b04
+ba30efdd-4207-4120-91dd-de5caed467ae
+9d20a879-6d33-43b4-b430-0c1cfaf5a7c4
+8f4002c0-d650-4252-943d-56287b6c6efe
+3c5c986e-1b69-4ff2-a470-0f677148240e
+f0ffb7ee-b7c6-4a07-814b-88d76b3cc3b8
+65ecca14-759e-41ee-b764-069ac0155df5
+36770cc9-d80b-405c-b9be-c5977ae3e83b
+4a4926a6-2a18-4b37-a361-581658a0f067
+15384749-bc5f-43ff-854e-b6495e0c6ee4
+2e8c0c9c-133a-4436-b1a4-3bb303ce7cd3'


### PR DESCRIPTION
This PR will update the `killHeldJobs` function to use `condor_q -constraint 'JobStatus =?= 5' -format "%s\n" IpcUuid` instead of `condor_q -long` when looking for jobs in the `held` state.

This will reduce the amount of output these functions need to parse, and hopefully also allows the `condor_q` command to run faster and use less resources.


This PR will also update the `killHeldJobs` ticker to call `condor_rm` directly.

This will prevent the `killHeldJobs` ticker from publishing the same stop requests over and over to the stop queue if that queue becomes backed up and can't catch up within the ticker's interval.