### PR TITLE
CORE-9171: refactor condor-launcher to facilitate multiple job submission formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 condor-launcher
+.idea/

--- a/condor.go
+++ b/condor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/streadway/amqp"
 	"github.com/cyverse-de/condor-launcher/jobs"
+	"github.com/constabulary/gb/cmd"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -166,6 +167,9 @@ func (cl *CondorLauncher) launch(s *model.Job, condorPath, condorConfig string) 
 		return "", err
 	}
 	submissionPath, err := jobSubmissionBuilder.Build(s, sdir)
+	if err != nil {
+		return "", err
+	}
 
 	// Submit the job to Condor.
 	cmd := exec.Command(cl.condorSubmit, submissionPath)

--- a/condor_test.go
+++ b/condor_test.go
@@ -50,118 +50,6 @@ func (t *tsys) WriteFile(path string, contents []byte, mode os.FileMode) error {
 	return nil
 }
 
-func TestGenerateCondorSubmit(t *testing.T) {
-	cfg := test.InitConfig(t)
-	s := test.InitTests(t, cfg)
-
-	actual, err := GenerateFile(SubmissionTemplate, s)
-	if err != nil {
-		t.Error(err)
-	}
-	expected := `universe = vanilla
-executable = /usr/local/bin/road-runner
-rank = mips
-requirements = (HAS_HOST_MOUNTS == True)
-arguments = --config config --job job
-output = script-output.log
-error = script-error.log
-log = condor.log
-accounting_group = de
-accounting_group_user = test_this_is_a_test
-request_disk = 0
-+IpcUuid = "07b04ce2-7757-4b21-9e15-0b4c2f44be26"
-+IpcJobId = "generated_script"
-+IpcUsername = "test_this_is_a_test"
-+IpcUserGroups = {"groups:foo","groups:bar","groups:baz"}
-concurrency_limits = _00000000000000000000000000000000
-+IpcExe = "wc_wrapper.sh"
-+IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-should_transfer_files = YES
-transfer_input_files = iplant.cmd,config,job
-transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
-when_to_transfer_output = ON_EXIT_OR_EVICT
-notification = NEVER
-queue
-`
-	if actual.String() != expected {
-		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
-	}
-}
-
-func TestGenerateCondorSubmitGroup(t *testing.T) {
-	cfg := test.InitConfig(t)
-	s := test.InitTests(t, cfg)
-	s.Group = "foo"
-	actual, err := GenerateFile(SubmissionTemplate, s)
-	if err != nil {
-		t.Error(err)
-	}
-	expected := `universe = vanilla
-executable = /usr/local/bin/road-runner
-rank = mips
-requirements = (HAS_HOST_MOUNTS == True)
-arguments = --config config --job job
-output = script-output.log
-error = script-error.log
-log = condor.log
-accounting_group = foo
-accounting_group_user = test_this_is_a_test
-request_disk = 0
-+IpcUuid = "07b04ce2-7757-4b21-9e15-0b4c2f44be26"
-+IpcJobId = "generated_script"
-+IpcUsername = "test_this_is_a_test"
-+IpcUserGroups = {"groups:foo","groups:bar","groups:baz"}
-concurrency_limits = _00000000000000000000000000000000
-+IpcExe = "wc_wrapper.sh"
-+IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-should_transfer_files = YES
-transfer_input_files = iplant.cmd,config,job
-transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
-when_to_transfer_output = ON_EXIT_OR_EVICT
-notification = NEVER
-queue
-`
-	if actual.String() != expected {
-		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
-	}
-}
-
-func TestGenerateCondorSubmitNoVolumes(t *testing.T) {
-	cfg := test.InitConfig(t)
-	s := test.InitTestsFromFile(t, cfg, "no_volumes_submission.json")
-	actual, err := GenerateFile(SubmissionTemplate, s)
-	if err != nil {
-		t.Error(err)
-	}
-	expected := `universe = vanilla
-executable = /usr/local/bin/road-runner
-rank = mips
-arguments = --config config --job job
-output = script-output.log
-error = script-error.log
-log = condor.log
-accounting_group = de
-accounting_group_user = test_this_is_a_test
-request_disk = 0
-+IpcUuid = "07b04ce2-7757-4b21-9e15-0b4c2f44be26"
-+IpcJobId = "generated_script"
-+IpcUsername = "test_this_is_a_test"
-+IpcUserGroups = {"groups:foo","groups:bar","groups:baz"}
-concurrency_limits = _00000000000000000000000000000000
-+IpcExe = "wc_wrapper.sh"
-+IpcExePath = "/usr/local3/bin/wc_tool-1.00"
-should_transfer_files = YES
-transfer_input_files = iplant.cmd,config,job
-transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
-when_to_transfer_output = ON_EXIT_OR_EVICT
-notification = NEVER
-queue
-`
-	if actual.String() != expected {
-		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
-	}
-}
-
 type VaultTester struct{}
 
 func (v *VaultTester) MountCubbyhole(mountPoint string) error {
@@ -178,6 +66,7 @@ func (v *VaultTester) StoreConfig(token, mountPoint, jobID string, config []byte
 
 func TestLaunch(t *testing.T) {
 	cfg := test.InitConfig(t)
+	test.InitPath(t)
 	csPath, err := exec.LookPath("condor_submit")
 	if err != nil {
 		t.Error(errors.Wrapf(err, "failed to find condor_submit in $PATH"))

--- a/jobs/condor.go
+++ b/jobs/condor.go
@@ -9,8 +9,27 @@ type CondorJobSubmissionBuilder struct {
 	cfg *viper.Viper
 }
 
-func (b CondorJobSubmissionBuilder) build(submission *model.Job, dirPath string) (string, error) {
+func (b CondorJobSubmissionBuilder) build(submission *model.Job, dirPath string) (*string, error) {
 
+	// Generate the submission file.
+	submitFilePath, err := generateFile(dirPath, "iplant.cmd", condorSubmissionTemplate, submission)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate the job configuration file.
+	_, err = generateFile(dirPath, "config", condorJobConfigTemplate, b.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write the job submission to a JSON file.
+	_, err = generateJson(dirPath, "job", submission)
+	if err != nil {
+		return nil, err
+	}
+
+	return submitFilePath, nil
 }
 
 func newCondorJobSubmissionBuilder(cfg *viper.Viper) JobSubmissionBuilder {

--- a/jobs/condor.go
+++ b/jobs/condor.go
@@ -9,24 +9,24 @@ type CondorJobSubmissionBuilder struct {
 	cfg *viper.Viper
 }
 
-func (b CondorJobSubmissionBuilder) build(submission *model.Job, dirPath string) (*string, error) {
+func (b CondorJobSubmissionBuilder) Build(submission *model.Job, dirPath string) (string, error) {
 
 	// Generate the submission file.
 	submitFilePath, err := generateFile(dirPath, "iplant.cmd", condorSubmissionTemplate, submission)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Generate the job configuration file.
 	_, err = generateFile(dirPath, "config", condorJobConfigTemplate, b.cfg)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Write the job submission to a JSON file.
 	_, err = generateJson(dirPath, "job", submission)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	return submitFilePath, nil

--- a/jobs/condor.go
+++ b/jobs/condor.go
@@ -1,0 +1,18 @@
+package jobs
+
+import (
+	"github.com/spf13/viper"
+	"gopkg.in/cyverse-de/model.v1"
+)
+
+type CondorJobSubmissionBuilder struct {
+	cfg *viper.Viper
+}
+
+func (b CondorJobSubmissionBuilder) build(submission *model.Job, dirPath string) (string, error) {
+
+}
+
+func newCondorJobSubmissionBuilder(cfg *viper.Viper) JobSubmissionBuilder {
+	return CondorJobSubmissionBuilder{cfg: cfg}
+}

--- a/jobs/condor_templates.go
+++ b/jobs/condor_templates.go
@@ -1,0 +1,91 @@
+package jobs
+
+import (
+	"text/template"
+	"log"
+	"github.com/pkg/errors"
+)
+
+var (
+	// condorSubmissionTemplate is a *template.Template for the HTCondor submission file
+	condorSubmissionTemplate *template.Template
+
+	// condorJobConfigTemplate is the *template.Template for the job definition JSON
+	condorJobConfigTemplate *template.Template
+
+	// condorIRODSConfigTemplate is the *template.Template for the iRODS config file
+	condorIRODSConfigTemplate *template.Template
+)
+
+// SubmissionTemplateText is the text of the template for the HTCondor
+// submission file.
+const condorSubmissionTemplateText = `universe = vanilla
+executable = /usr/local/bin/road-runner
+rank = mips{{ if .UsesVolumes }}
+requirements = (HAS_HOST_MOUNTS == True){{ end }}
+arguments = --config config --job job
+output = script-output.log
+error = script-error.log
+log = condor.log
+accounting_group = {{if .Group}}{{.Group}}{{else}}de{{end}}
+accounting_group_user = {{.Submitter}}
+request_disk = {{.RequestDisk}}
++IpcUuid = "{{.InvocationID}}"
++IpcJobId = "generated_script"
++IpcUsername = "{{.Submitter}}"
++IpcUserGroups = {{.FormatUserGroups}}
+concurrency_limits = {{.UserIDForSubmission}}
+{{with $x := index .Steps 0}}+IpcExe = "{{$x.Component.Name}}"{{end}}
+{{with $x := index .Steps 0}}+IpcExePath = "{{$x.Component.Location}}"{{end}}
+should_transfer_files = YES
+transfer_input_files = iplant.cmd,config,job
+transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
+when_to_transfer_output = ON_EXIT_OR_EVICT
+notification = NEVER
+queue
+`
+
+// JobConfigTemplateText is the text of the template for the HTCondor submission
+// file.
+const condorJobConfigTemplateText = `amqp:
+    uri: {{.GetString "amqp.uri"}}
+    exchange:
+        name: {{.GetString "amqp.exchange.name"}}
+        type: {{.GetString "amqp.exchange.type"}}
+irods:
+    base: "{{.GetString "irods.base"}}"
+porklock:
+    image: "{{.GetString "porklock.image"}}"
+    tag: "{{.GetString "porklock.tag"}}"
+condor:
+    filter_files: "{{.GetString "condor.filter_files"}}"
+vault:
+    token: "{{.GetString "vault.child_token.token"}}"
+    url: "{{.GetString "vault.url"}}"`
+
+// IRODSConfigTemplateText is the text of the template for porklock's iRODS
+// config file.
+const condorIRODSConfigTemplateText = `porklock.irods-host = {{.IRODSHost}}
+porklock.irods-port = {{.IRODSPort}}
+porklock.irods-user = {{.IRODSUser}}
+porklock.irods-pass = {{.IRODSPass}}
+porklock.irods-home = {{.IRODSBase}}
+porklock.irods-zone = {{.IRODSZone}}
+porklock.irods-resc = {{.IRODSResc}}
+`
+
+func init() {
+	var err error
+	condorSubmissionTemplate, err = template.New("condor_submit").Parse(condorSubmissionTemplateText)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to parse submission template text"))
+	}
+	condorJobConfigTemplate, err = template.New("job_config").Parse(condorJobConfigTemplateText)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to parse job config template text"))
+	}
+	condorIRODSConfigTemplate, err = template.New("irods_config").Parse(condorIRODSConfigTemplateText)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to parse irods config template text"))
+	}
+}

--- a/jobs/condor_templates.go
+++ b/jobs/condor_templates.go
@@ -12,9 +12,6 @@ var (
 
 	// condorJobConfigTemplate is the *template.Template for the job definition JSON
 	condorJobConfigTemplate *template.Template
-
-	// condorIRODSConfigTemplate is the *template.Template for the iRODS config file
-	condorIRODSConfigTemplate *template.Template
 )
 
 // SubmissionTemplateText is the text of the template for the HTCondor
@@ -63,17 +60,6 @@ vault:
     token: "{{.GetString "vault.child_token.token"}}"
     url: "{{.GetString "vault.url"}}"`
 
-// IRODSConfigTemplateText is the text of the template for porklock's iRODS
-// config file.
-const condorIRODSConfigTemplateText = `porklock.irods-host = {{.IRODSHost}}
-porklock.irods-port = {{.IRODSPort}}
-porklock.irods-user = {{.IRODSUser}}
-porklock.irods-pass = {{.IRODSPass}}
-porklock.irods-home = {{.IRODSBase}}
-porklock.irods-zone = {{.IRODSZone}}
-porklock.irods-resc = {{.IRODSResc}}
-`
-
 func init() {
 	var err error
 	condorSubmissionTemplate, err = template.New("condor_submit").Parse(condorSubmissionTemplateText)
@@ -83,9 +69,5 @@ func init() {
 	condorJobConfigTemplate, err = template.New("job_config").Parse(condorJobConfigTemplateText)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse job config template text"))
-	}
-	condorIRODSConfigTemplate, err = template.New("irods_config").Parse(condorIRODSConfigTemplateText)
-	if err != nil {
-		log.Fatal(errors.Wrap(err, "failed to parse irods config template text"))
 	}
 }

--- a/jobs/condor_templates_test.go
+++ b/jobs/condor_templates_test.go
@@ -1,0 +1,118 @@
+package jobs
+
+import (
+	"testing"
+	"github.com/cyverse-de/condor-launcher/test"
+)
+
+func TestGenerateCondorSubmit(t *testing.T) {
+	cfg := test.InitConfig(t)
+	s := test.InitTests(t, cfg)
+
+	actual, err := generateFileContents(condorSubmissionTemplate, s)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := `universe = vanilla
+executable = /usr/local/bin/road-runner
+rank = mips
+requirements = (HAS_HOST_MOUNTS == True)
+arguments = --config config --job job
+output = script-output.log
+error = script-error.log
+log = condor.log
+accounting_group = de
+accounting_group_user = test_this_is_a_test
+request_disk = 0
++IpcUuid = "07b04ce2-7757-4b21-9e15-0b4c2f44be26"
++IpcJobId = "generated_script"
++IpcUsername = "test_this_is_a_test"
++IpcUserGroups = {"groups:foo","groups:bar","groups:baz"}
+concurrency_limits = _00000000000000000000000000000000
++IpcExe = "wc_wrapper.sh"
++IpcExePath = "/usr/local3/bin/wc_tool-1.00"
+should_transfer_files = YES
+transfer_input_files = iplant.cmd,config,job
+transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
+when_to_transfer_output = ON_EXIT_OR_EVICT
+notification = NEVER
+queue
+`
+	if actual.String() != expected {
+		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
+	}
+}
+
+func TestGenerateCondorSubmitGroup(t *testing.T) {
+	cfg := test.InitConfig(t)
+	s := test.InitTests(t, cfg)
+	s.Group = "foo"
+	actual, err := generateFileContents(condorSubmissionTemplate, s)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := `universe = vanilla
+executable = /usr/local/bin/road-runner
+rank = mips
+requirements = (HAS_HOST_MOUNTS == True)
+arguments = --config config --job job
+output = script-output.log
+error = script-error.log
+log = condor.log
+accounting_group = foo
+accounting_group_user = test_this_is_a_test
+request_disk = 0
++IpcUuid = "07b04ce2-7757-4b21-9e15-0b4c2f44be26"
++IpcJobId = "generated_script"
++IpcUsername = "test_this_is_a_test"
++IpcUserGroups = {"groups:foo","groups:bar","groups:baz"}
+concurrency_limits = _00000000000000000000000000000000
++IpcExe = "wc_wrapper.sh"
++IpcExePath = "/usr/local3/bin/wc_tool-1.00"
+should_transfer_files = YES
+transfer_input_files = iplant.cmd,config,job
+transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
+when_to_transfer_output = ON_EXIT_OR_EVICT
+notification = NEVER
+queue
+`
+	if actual.String() != expected {
+		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
+	}
+}
+
+func TestGenerateCondorSubmitNoVolumes(t *testing.T) {
+	cfg := test.InitConfig(t)
+	s := test.InitTestsFromFile(t, cfg, "no_volumes_submission.json")
+	actual, err := generateFileContents(condorSubmissionTemplate, s)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := `universe = vanilla
+executable = /usr/local/bin/road-runner
+rank = mips
+arguments = --config config --job job
+output = script-output.log
+error = script-error.log
+log = condor.log
+accounting_group = de
+accounting_group_user = test_this_is_a_test
+request_disk = 0
++IpcUuid = "07b04ce2-7757-4b21-9e15-0b4c2f44be26"
++IpcJobId = "generated_script"
++IpcUsername = "test_this_is_a_test"
++IpcUserGroups = {"groups:foo","groups:bar","groups:baz"}
+concurrency_limits = _00000000000000000000000000000000
++IpcExe = "wc_wrapper.sh"
++IpcExePath = "/usr/local3/bin/wc_tool-1.00"
+should_transfer_files = YES
+transfer_input_files = iplant.cmd,config,job
+transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
+when_to_transfer_output = ON_EXIT_OR_EVICT
+notification = NEVER
+queue
+`
+	if actual.String() != expected {
+		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
+	}
+}

--- a/jobs/main.go
+++ b/jobs/main.go
@@ -8,7 +8,7 @@ import (
 
 // JobSubmissionBuilder is an interface for generating Condor job submissions.
 type JobSubmissionBuilder interface {
-	build(submission *model.Job, dirPath string) (*string, error)
+	Build(submission *model.Job, dirPath string) (string, error)
 }
 
 func NewJobSubmissionBuilder(jobType string, cfg *viper.Viper) (JobSubmissionBuilder, error) {

--- a/jobs/main.go
+++ b/jobs/main.go
@@ -8,7 +8,7 @@ import (
 
 // JobSubmissionBuilder is an interface for generating Condor job submissions.
 type JobSubmissionBuilder interface {
-	build(submission *model.Job, dirPath string) (string, error)
+	build(submission *model.Job, dirPath string) (*string, error)
 }
 
 func NewJobSubmissionBuilder(jobType string, cfg *viper.Viper) (JobSubmissionBuilder, error) {

--- a/jobs/main.go
+++ b/jobs/main.go
@@ -1,0 +1,19 @@
+package jobs
+
+import (
+	"github.com/spf13/viper"
+	"gopkg.in/cyverse-de/model.v1"
+	"fmt"
+)
+
+// JobSubmissionBuilder is an interface for generating Condor job submissions.
+type JobSubmissionBuilder interface {
+	build(submission *model.Job, dirPath string) (string, error)
+}
+
+func NewJobSubmissionBuilder(jobType string, cfg *viper.Viper) (JobSubmissionBuilder, error) {
+	if jobType == "condor" {
+		return newCondorJobSubmissionBuilder(cfg), nil
+	}
+	return nil, fmt.Errorf("unrecognized job submission type: %s\n", jobType)
+}

--- a/jobs/utils.go
+++ b/jobs/utils.go
@@ -9,23 +9,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-func generateFile(dirPath, filename string, t *template.Template, data interface{}) (*string, error) {
+func generateFile(dirPath, filename string, t *template.Template, data interface{}) (string, error) {
 
 	// Open the output file for writing.
 	filePath := path.Join(dirPath, filename)
 	out, err := os.OpenFile(filePath, os.O_CREATE | os.O_WRONLY, 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err,"unable to open %s for output", filePath)
+		return "", errors.Wrapf(err,"unable to open %s for output", filePath)
 	}
 	defer out.Close()
 
 	// Generate the file from the template.
 	err = t.Execute(out, data)
 	if err != nil {
-		return nil, errors.Wrapf(err,"unable to generate %s from template %s", filePath, t.Name())
+		return "", errors.Wrapf(err,"unable to generate %s from template %s", filePath, t.Name())
 	}
 
-	return &filePath, nil
+	return filePath, nil
 }
 
 func generateFileContents(t *template.Template, data interface{}) (*bytes.Buffer, error) {
@@ -37,13 +37,13 @@ func generateFileContents(t *template.Template, data interface{}) (*bytes.Buffer
 	return &buffer, err
 }
 
-func generateJson(dirPath, filename string, data interface{}) (*string, error) {
+func generateJson(dirPath, filename string, data interface{}) (string, error) {
 
 	// Open the output file for writing.
 	filePath := path.Join(dirPath, filename)
 	out, err := os.OpenFile(filePath, os.O_CREATE | os.O_WRONLY, 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err,"unable to open %s for output", filePath)
+		return "", errors.Wrapf(err,"unable to open %s for output", filePath)
 	}
 	defer out.Close()
 
@@ -51,8 +51,8 @@ func generateJson(dirPath, filename string, data interface{}) (*string, error) {
 	encoder := json.NewEncoder(out)
 	err = encoder.Encode(data)
 	if err != nil {
-		return nil, errors.Wrapf(err,"unable to marshal JSON to %s", filePath)
+		return "", errors.Wrapf(err,"unable to marshal JSON to %s", filePath)
 	}
 
-	return &filePath, nil
+	return filePath, nil
 }

--- a/jobs/utils.go
+++ b/jobs/utils.go
@@ -1,0 +1,58 @@
+package jobs
+
+import (
+	"text/template"
+	"path"
+	"os"
+	"encoding/json"
+	"bytes"
+	"github.com/pkg/errors"
+)
+
+func generateFile(dirPath, filename string, t *template.Template, data interface{}) (*string, error) {
+
+	// Open the output file for writing.
+	filePath := path.Join(dirPath, filename)
+	out, err := os.OpenFile(filePath, os.O_CREATE | os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, errors.Wrapf(err,"unable to open %s for output", filePath)
+	}
+	defer out.Close()
+
+	// Generate the file from the template.
+	err = t.Execute(out, data)
+	if err != nil {
+		return nil, errors.Wrapf(err,"unable to generate %s from template %s", filePath, t.Name())
+	}
+
+	return &filePath, nil
+}
+
+func generateFileContents(t *template.Template, data interface{}) (*bytes.Buffer, error) {
+	var buffer bytes.Buffer
+	err := t.Execute(&buffer, data)
+	if err != nil {
+		return &buffer, errors.Wrapf(err, "failed to apply data to the %s template", t.Name())
+	}
+	return &buffer, err
+}
+
+func generateJson(dirPath, filename string, data interface{}) (*string, error) {
+
+	// Open the output file for writing.
+	filePath := path.Join(dirPath, filename)
+	out, err := os.OpenFile(filePath, os.O_CREATE | os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, errors.Wrapf(err,"unable to open %s for output", filePath)
+	}
+	defer out.Close()
+
+	// Generate the output JSON.
+	encoder := json.NewEncoder(out)
+	err = encoder.Encode(data)
+	if err != nil {
+		return nil, errors.Wrapf(err,"unable to marshal JSON to %s", filePath)
+	}
+
+	return &filePath, nil
+}

--- a/stops_test.go
+++ b/stops_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/cyverse-de/messaging.v3"
 
 	"github.com/streadway/amqp"
+	"github.com/cyverse-de/condor-launcher/test"
 )
 
 var client *messaging.Client
@@ -132,7 +133,7 @@ func TestCondorID(t *testing.T) {
 }
 
 func TestExecCondorQ(t *testing.T) {
-	inittests(t)
+	test.InitPath(t)
 	output, err := ExecCondorQHeldIDs("", "")
 	if err != nil {
 		t.Error(err)
@@ -158,7 +159,7 @@ func TestExecCondorQ(t *testing.T) {
 }
 
 func TestExecCondorRm(t *testing.T) {
-	inittests(t)
+	test.InitPath(t)
 	actual, err := ExecCondorRm("foo", "", "")
 	if err != nil {
 		t.Error(err)
@@ -178,7 +179,8 @@ func TestStopHandler(t *testing.T) {
 	if !shouldrun() {
 		return
 	}
-	inittests(t)
+	cfg := test.InitConfig(t)
+	test.InitPath(t)
 	filesystem := newtsys()
 	cl := New(cfg, nil, filesystem, "condor_submit", "condor_rm")
 	stopMsg := messaging.StopRequest{

--- a/templates.go
+++ b/templates.go
@@ -8,61 +8,9 @@ import (
 )
 
 var (
-	// SubmissionTemplate is a *template.Template for the HTCondor submission file
-	SubmissionTemplate *template.Template
-
-	// JobConfigTemplate is the *template.Template for the job definition JSON
-	JobConfigTemplate *template.Template
-
 	// IRODSConfigTemplate is the *template.Template for the iRODS config file
 	IRODSConfigTemplate *template.Template
 )
-
-// SubmissionTemplateText is the text of the template for the HTCondor
-// submission file.
-const SubmissionTemplateText = `universe = vanilla
-executable = /usr/local/bin/road-runner
-rank = mips{{ if .UsesVolumes }}
-requirements = (HAS_HOST_MOUNTS == True){{ end }}
-arguments = --config config --job job
-output = script-output.log
-error = script-error.log
-log = condor.log
-accounting_group = {{if .Group}}{{.Group}}{{else}}de{{end}}
-accounting_group_user = {{.Submitter}}
-request_disk = {{.RequestDisk}}
-+IpcUuid = "{{.InvocationID}}"
-+IpcJobId = "generated_script"
-+IpcUsername = "{{.Submitter}}"
-+IpcUserGroups = {{.FormatUserGroups}}
-concurrency_limits = {{.UserIDForSubmission}}
-{{with $x := index .Steps 0}}+IpcExe = "{{$x.Component.Name}}"{{end}}
-{{with $x := index .Steps 0}}+IpcExePath = "{{$x.Component.Location}}"{{end}}
-should_transfer_files = YES
-transfer_input_files = iplant.cmd,config,job
-transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
-when_to_transfer_output = ON_EXIT_OR_EVICT
-notification = NEVER
-queue
-`
-
-// JobConfigTemplateText is the text of the template for the HTCondor submission
-// file.
-const JobConfigTemplateText = `amqp:
-    uri: {{.GetString "amqp.uri"}}
-    exchange:
-        name: {{.GetString "amqp.exchange.name"}}
-        type: {{.GetString "amqp.exchange.type"}}
-irods:
-    base: "{{.GetString "irods.base"}}"
-porklock:
-    image: "{{.GetString "porklock.image"}}"
-    tag: "{{.GetString "porklock.tag"}}"
-condor:
-    filter_files: "{{.GetString "condor.filter_files"}}"
-vault:
-    token: "{{.GetString "vault.child_token.token"}}"
-    url: "{{.GetString "vault.url"}}"`
 
 // IRODSConfigTemplateText is the text of the template for porklock's iRODS
 // config file.

--- a/test/utils.go
+++ b/test/utils.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"runtime"
 	"path"
+	"strings"
 )
 
 func getTestConfigDir(t *testing.T) string {
@@ -25,8 +26,16 @@ func getTestFilePath(t *testing.T, filename string) string {
 }
 
 func InitPath(t *testing.T) {
-	PATH := fmt.Sprintf("%s:%s", getTestConfigDir(t), os.Getenv("PATH"))
-	err := os.Setenv("PATH", PATH)
+	dir := getTestConfigDir(t)
+	path := os.Getenv("PATH")
+
+	// Don't bother updating the path if the test config directory is already in it.
+	if strings.HasPrefix(path, fmt.Sprintf("%s:", dir)) {
+		return
+	}
+
+	// Update the path.
+	err := os.Setenv("PATH", fmt.Sprintf("%s:%s", dir, path))
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,88 @@
+package test
+
+import (
+	"testing"
+	"github.com/cyverse-de/configurate"
+	"fmt"
+	"os"
+	"gopkg.in/cyverse-de/model.v1"
+	"github.com/spf13/viper"
+	"io/ioutil"
+	"runtime"
+	"path"
+)
+
+func getTestConfigDir(t *testing.T) string {
+	_, sourcePath, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Errorf("unable to determine the path to the current source file")
+	}
+	return path.Dir(sourcePath)
+}
+
+func getTestFilePath(t *testing.T, filename string) string {
+	return path.Join(getTestConfigDir(t), filename)
+}
+
+func InitPath(t *testing.T) {
+	PATH := fmt.Sprintf("%s:%s", getTestConfigDir(t), os.Getenv("PATH"))
+	err := os.Setenv("PATH", PATH)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func InitConfig(t *testing.T) *viper.Viper {
+
+	// Load the test configuration.
+	path := getTestFilePath(t, "test_config.yaml")
+	cfg, err := configurate.InitDefaults(path, configurate.JobServicesDefaults)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Set test configuration values.
+	cfg.Set("irods.base", "/path/to/irodsbase")
+	cfg.Set("irods.host", "hostname")
+	cfg.Set("irods.port", "1247")
+	cfg.Set("irods.user", "user")
+	cfg.Set("irods.pass", "pass")
+	cfg.Set("irods.zone", "test")
+	cfg.Set("irods.resc", "")
+	cfg.Set("condor.log_path", "test")
+	cfg.Set("condor.porklock_tag", "test")
+	cfg.Set("condor.filter_files", "foo,bar,baz,blippy")
+	cfg.Set("condor.request_disk", "0")
+	cfg.Set("condor.path_env_var", "/path/to/path")
+	cfg.Set("condor.condor_config", "/condor/config")
+	cfg.Set("vault.irods.child_token.token", "token")
+	cfg.Set("vault.irods.child_token.use_limit", 3)
+	cfg.Set("vault.irods.mount_path", "irods")
+
+	return cfg
+}
+
+func InitTestsFromFile(t *testing.T, cfg *viper.Viper, filename string) *model.Job {
+
+	// Load the job submission information from the file.
+	path := getTestFilePath(t, filename)
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Parse the job submission information.
+	s, err := model.NewFromData(cfg, data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Add the test configuration directory to the PATH.
+	InitPath(t)
+
+	return s
+}
+
+func InitTests(t *testing.T, cfg *viper.Viper) *model.Job {
+	return InitTestsFromFile(t, cfg, "test_submission.json")
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// toAbsolutePath converts a relative path to an absolute path, logging a fatal error if the path can't be converted.
+func toAbsolutePath(relPath string) string {
+	absPath, err := filepath.Abs(relPath)
+	if err != nil {
+		log.Fatal(errors.Wrapf(err, "failed to get the absolute path to %s", relPath))
+	}
+	return absPath
+}
+
+// findExecPath finds the absolute path of an executable file somewhere in the search path, logging a fatal error if
+// the executable file can't be found.
+func findExecPath(execName string) string {
+	execPath, err := exec.LookPath(execName)
+	if err != nil {
+		log.Fatal(errors.Wrapf(err, "failed to find %s in $PATH", execName))
+	}
+	return toAbsolutePath(execPath)
+}


### PR DESCRIPTION
This work isn't completely done yet, but covers the purposes of CORE-9171. The first purpose was simply to give me something to do while familiarizing myself with condor-launcher. The second was to make it easier to add new submission formats in the future. The remaining tasks that I can think of are:

- decide how OSG job submissions should be formatted;
- decide how the job format should be communicated to condor-launcher;
- update the job submission model to include the job format indicator;
- update condor-launcher and jex-adapter to use the new model;
- modify condor-launcher to support the OSG job submission format;
- modify apps to send the job format indicator to jex-adapter.

There are probably some tasks that I haven't thought of, but this should be a good start.